### PR TITLE
[Bug(auth)] Jwt 예외 응답이 클라이언트에게 전달되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/saisai/config/SecurityConfig.java
+++ b/src/main/java/com/saisai/config/SecurityConfig.java
@@ -23,6 +23,7 @@ public class SecurityConfig {
     private final JwtProvider jwtProvider;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -52,7 +53,7 @@ public class SecurityConfig {
                 .accessDeniedHandler(jwtAccessDeniedHandler)
                 .authenticationEntryPoint(jwtAuthenticationEntryPoint)
             )
-            .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
             .build();
     }
 

--- a/src/main/java/com/saisai/config/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/saisai/config/jwt/JwtAccessDeniedHandler.java
@@ -1,5 +1,7 @@
 package com.saisai.config.jwt;
 
+import static com.saisai.domain.common.exception.ExceptionCode.ADMIN_REQUIRED;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saisai.domain.common.exception.ExceptionResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,10 +26,12 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 
-        ExceptionResponse body = new ExceptionResponse("ACCESS_DENIED", "관리자 권한이 필요한 요청입니다. 접근 권한이 없습니다.");
+        ExceptionResponse body = new ExceptionResponse(ADMIN_REQUIRED.getCode(),
+            ADMIN_REQUIRED.getMessage());
         String json = objectMapper.writeValueAsString(body);
 
         response.getWriter().write(json);
+        response.getWriter().flush();
     }
 }
 

--- a/src/main/java/com/saisai/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/saisai/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,12 +1,13 @@
 package com.saisai.config.jwt;
 
+import static com.saisai.domain.common.exception.ExceptionCode.USER_NOT_AUTHENTICATED;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.saisai.domain.common.exception.ExceptionResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.io.PrintWriter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -25,33 +26,16 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException) throws IOException, ServletException {
 
-        // JwtAuthenticationException에서 HTTP 상태 코드와 에러 코드를 가져옴
-        int status;
-        String code;
-        String message;
-
-        if (authException instanceof JwtAuthenticationException jwtEx) {
-            status = jwtEx.getHttpStatus().value();
-            code = jwtEx.getCode();
-            message = jwtEx.getMessage();
-            log.info(message);
-        } else {
-            log.info("왜 인증 안됨");
-            status = HttpServletResponse.SC_UNAUTHORIZED;
-            code = "UNAUTHORIZED";
-            message = "인증되지 않은 사용자입니다.";
-        }
-
-        response.setStatus(status);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ExceptionResponse errorResponse = new ExceptionResponse(code, message);
+        ExceptionResponse errorResponse = new ExceptionResponse(
+            USER_NOT_AUTHENTICATED.getCode(),
+            USER_NOT_AUTHENTICATED.getMessage()
+        );
 
-        PrintWriter out = response.getWriter();
-        log.info(out.toString());
-        objectMapper.writeValue(out, errorResponse);
-        out.flush();
-
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+        response.getWriter().flush();
     }
 }

--- a/src/main/java/com/saisai/config/jwt/JwtProvider.java
+++ b/src/main/java/com/saisai/config/jwt/JwtProvider.java
@@ -111,7 +111,6 @@ public class JwtProvider {
     // 토큰 유효성 검사하는 메서드
     public boolean validToken(String token) {
         try{
-            log.info("valid 도착");
             Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()

--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -53,7 +53,7 @@ public enum ExceptionCode {
 
     // etc
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "ETC_ER_01", "요청하신 페이지 번호가 유효 범위를 초과했습니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ETC_ER_02", "서버가 응답할 수 없습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ETC_ER_02", "서버가 응답할 수 없습니다."),
     SERVER_IMAGE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "ETC_ER_03", "이미지 서버에 문제가 생겼습니다."),
     ;
 

--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -16,6 +16,8 @@ public enum ExceptionCode {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_ER_05", "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_ER_06", "지원되지 않는 JWT 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_ER_07", "유효하지 않은 Refresh 토큰입니다."),
+    USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH_ER_09", "인증되지 않았습니다."),
+
 
     // user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_ER_01", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -16,6 +16,7 @@ public enum ExceptionCode {
     EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_ER_05", "만료된 JWT 토큰입니다."),
     UNSUPPORTED_JWT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_ER_06", "지원되지 않는 JWT 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_ER_07", "유효하지 않은 Refresh 토큰입니다."),
+    ADMIN_REQUIRED(HttpStatus.FORBIDDEN, "AUTH_ER_08", "관리자 권한이 필요한 요청입니다. 접근 권한이 없습니다."),
     USER_NOT_AUTHENTICATED(HttpStatus.UNAUTHORIZED, "AUTH_ER_09", "인증되지 않았습니다."),
 
 


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #19 

## 📝 요약

> Spring Security가 이미 처리된 응답을 다시 처리하려 시도해 JWT 인증 필터에서 토큰 관련 예외(`EXPIRED_JWT_TOKEN`, `INVALID_JWT_SIGNATURE` 등)가 발생했을 때, 서버 로그에는 예외가 기록되지만 클라이언트에게는 구체적인 에러 메시지가 전달되지 않고 일반적인 “인증되지 않은 사용자” 메시지만 응답되는 문제를 해결함

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
