### PR TITLE
[Refactor(ride)] 최근 라이드 한 코스 조회 시 반환 유형 추가

### DIFF
--- a/src/main/java/com/saisai/domain/ride/dto/response/RecentRideInfoRes.java
+++ b/src/main/java/com/saisai/domain/ride/dto/response/RecentRideInfoRes.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 public record RecentRideInfoRes(
     String courseName,
     String sigun,
-    String courseIamgeUrl,
+    String courseImageUrl,
     Double distance,
     Double progressRate,
     LocalDate recentRideAt
@@ -27,6 +27,17 @@ public record RecentRideInfoRes(
             courseItem.distance(),
             ride.getProgressRate(),
             ride.getModifiedAt().toLocalDate()
+        );
+    }
+
+    public static RecentRideInfoRes empty() {
+        return new RecentRideInfoRes(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
         );
     }
 }

--- a/src/main/java/com/saisai/domain/ride/service/MyRideService.java
+++ b/src/main/java/com/saisai/domain/ride/service/MyRideService.java
@@ -33,14 +33,14 @@ public class MyRideService {
         Ride recentRide = rideRepository.findTop1ByUserIdOrderByModifiedAtDesc(user.getId());
 
         if (recentRide == null) {
-            return null;
+            return RecentRideInfoRes.empty();
         }
 
-        CourseItem couresItem = courseService.findCourseByName(recentRide.getCourseName())
+        CourseItem courseItem = courseService.findCourseByName(recentRide.getCourseName())
             .orElseThrow(() -> new CustomException(COURSE_NOT_FOUND));
 
         CourseImage courseImage = courseImageRepository.findCourseImageByCourseName(recentRide.getCourseName());
 
-        return RecentRideInfoRes.from(recentRide, couresItem, courseImage);
+        return RecentRideInfoRes.from(recentRide, courseItem, courseImage);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #27

## 📝 요약

> 최근 라이드 한 코스가 없을 때 조회 시 empty 응답 구조로 반환 됨
이에 대해서 데이터 파싱에 대해 불편함이 존재해 empty가 아닌 각 요소들이 null을 반환하도록 하는 수정

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
