### PR TITLE
[Feature(course)] 코스상세조회 API 반환 필드 추가

### DIFF
--- a/src/main/java/com/saisai/domain/course/controller/CourseController.java
+++ b/src/main/java/com/saisai/domain/course/controller/CourseController.java
@@ -46,7 +46,7 @@ public class CourseController {
     }
 
     @Operation(summary = "코스 상세 조회",
-        description = "코스ID, 코스명, 코스 설명, 난이도(상(3)/중(2)/하(1)), 거리(km), 예상 소요시간(분), 시군(지역), gpx경로(위도, 경도, 고도, 앞뒤 좌표 거리(m), 현재까지의 누적 거리(km)), 도전자 수, 완주자 수, 라이딩 중단 기록 여부, 테마 반환 ")
+        description = "코스ID, 코스명, 코스 설명, 난이도(상(3)/중(2)/하(1)), 거리(km), 예상 소요시간(분), 시군(지역), gpx경로(위도, 경도, 고도, 앞뒤 좌표 거리(m), 현재까지의 누적 거리(km)), 도전자 수, 완주자 수, 라이딩 중단 기록 여부, 챌린지 종료일(Ended(종료), Ongoing(진행중), null), 챌린지 종료일, 이벤트 여부, 테마 반환 ")
     @GetMapping("/{courseId}")
     public ResponseEntity<ApiResponse<CourseDetailsRes>> getCourseInfo(
         @PathVariable Long courseId,

--- a/src/main/java/com/saisai/domain/course/dto/projection/CourseDetailsProjection.java
+++ b/src/main/java/com/saisai/domain/course/dto/projection/CourseDetailsProjection.java
@@ -1,0 +1,23 @@
+package com.saisai.domain.course.dto.projection;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.saisai.domain.challenge.entity.ChallengeStatus;
+import java.time.LocalDateTime;
+
+public record CourseDetailsProjection(
+    Long id,
+    String name,
+    String summary,
+    Integer level,
+    Double distance,
+    Double estimatedTime,
+    String sigun,
+    String imageUrl,
+    String gpxpath,
+    ChallengeStatus challengeStatus,
+    LocalDateTime challengeEndedAt,
+    Boolean isEventActive
+) {
+    @QueryProjection
+    public CourseDetailsProjection {}
+}

--- a/src/main/java/com/saisai/domain/course/dto/projection/CoursePageProjection.java
+++ b/src/main/java/com/saisai/domain/course/dto/projection/CoursePageProjection.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 public record CoursePageProjection(
     Long courseId,
     String courseName,
-    String summary,
     Integer level,
     Double distance,
     Double estimatedTime,

--- a/src/main/java/com/saisai/domain/course/dto/response/CourseDetailsRes.java
+++ b/src/main/java/com/saisai/domain/course/dto/response/CourseDetailsRes.java
@@ -1,9 +1,13 @@
 package com.saisai.domain.course.dto.response;
 
-import com.saisai.domain.course.entity.Course;
+import com.saisai.domain.challenge.entity.ChallengeStatus;
+import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
 import com.saisai.domain.gpx.dto.GpxPoint;
 import com.saisai.domain.ride.dto.response.RideCountRes;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public record CourseDetailsRes(
     Long courseId,
@@ -17,22 +21,33 @@ public record CourseDetailsRes(
     Long challengerCount,
     Long finisherCount,
     Boolean hasUncompletedRide,
+    ChallengeStatus challengeStatus,
+    LocalDate challengeEndedAt,
+    Boolean isEventActive,
     List<String> themeNames,
     List<GpxPoint> gpxPoints
 ) {
-    public static CourseDetailsRes from(Course course, String imageUrl, RideCountRes rideCountRes, List<GpxPoint> gpxPoints, boolean hasUncompletedRide, List<String> themeNames) {
+    public static CourseDetailsRes from(CourseDetailsProjection course, String imageUrl, RideCountRes rideCountRes, List<GpxPoint> gpxPoints, boolean hasUncompletedRide, List<String> themeNames) {
+
+        LocalDate challengeEndedAt = Optional.ofNullable(course.challengeEndedAt())
+            .map(LocalDateTime::toLocalDate)
+            .orElse(null);
+
         return new CourseDetailsRes(
-            course.getId(),
-            course.getName(),
-            course.getSummary(),
-            course.getLevel(),
-            course.getDistance(),
-            course.getEstimatedTime(),
-            course.getSigun(),
+            course.id(),
+            course.name(),
+            course.summary(),
+            course.level(),
+            course.distance(),
+            course.estimatedTime(),
+            course.sigun(),
             imageUrl,
             rideCountRes.courseChallengerCount(),
             rideCountRes.courseFinisherCount(),
             hasUncompletedRide,
+            course.challengeStatus(),
+            challengeEndedAt,
+            course.isEventActive(),
             themeNames,
             gpxPoints
         );

--- a/src/main/java/com/saisai/domain/course/dto/response/CoursePageRes.java
+++ b/src/main/java/com/saisai/domain/course/dto/response/CoursePageRes.java
@@ -11,7 +11,6 @@ import java.util.List;
 public record CoursePageRes(
     Long courseId,
     String courseName,
-    String summary,
     Integer level,
     Double distance,
     Double estimatedTime,
@@ -41,7 +40,6 @@ public record CoursePageRes(
         return new CoursePageRes(
             coursePageProjection.courseId(),
             coursePageProjection.courseName(),
-            coursePageProjection.summary(),
             coursePageProjection.level(),
             coursePageProjection.distance(),
             coursePageProjection.estimatedTime(),

--- a/src/main/java/com/saisai/domain/course/repository/CourseRepositoryCustom.java
+++ b/src/main/java/com/saisai/domain/course/repository/CourseRepositoryCustom.java
@@ -1,8 +1,10 @@
 package com.saisai.domain.course.repository;
 
 import com.saisai.domain.course.dto.projection.CourseCardProjection;
+import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
 import com.saisai.domain.course.dto.projection.CoursePageProjection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +12,6 @@ public interface CourseRepositoryCustom {
     Page<CoursePageProjection> findCoursesByChallengeStatus(String challengeStatus, Pageable pageable);
 
     List<CourseCardProjection> findCourseCardByIds(List<Long> courseIds);
+
+    Optional<CourseDetailsProjection> findCourseDetailsProjection(Long courseId);
 }

--- a/src/main/java/com/saisai/domain/course/repository/CourseRepositoryImpl.java
+++ b/src/main/java/com/saisai/domain/course/repository/CourseRepositoryImpl.java
@@ -6,16 +6,20 @@ import static com.saisai.domain.reward.entity.QEventCourse.eventCourse;
 import static com.saisai.domain.reward.entity.QRewardEvent.rewardEvent;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.saisai.domain.challenge.entity.ChallengeStatus;
 import com.saisai.domain.course.dto.projection.CourseCardProjection;
+import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
 import com.saisai.domain.course.dto.projection.CoursePageProjection;
 import com.saisai.domain.course.dto.projection.QCourseCardProjection;
+import com.saisai.domain.course.dto.projection.QCourseDetailsProjection;
 import com.saisai.domain.course.dto.projection.QCoursePageProjection;
 import com.saisai.domain.reward.dto.projection.QRewardEventProjection;
 import com.saisai.domain.reward.entity.EventStatus;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -42,7 +46,6 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
             .select(new QCoursePageProjection(
                 course.id,
                 course.name,
-                course.summary,
                 course.level,
                 course.distance,
                 course.estimatedTime,
@@ -71,8 +74,7 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
             .from(challenge)
             .join(challenge.course, course)
             .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent)
-                .and(rewardEvent.status.eq(EventStatus.ACTIVE)))
+            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent))
             .where(searchConditions);
 
         return PageableExecutionUtils.getPage(content, pageable, total::fetchOne);
@@ -99,10 +101,40 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
             ))
             .from(course)
             .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent)
-                .and(rewardEvent.status.eq(EventStatus.ACTIVE)))
+            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent))
             .where(course.id.in(courseIds))
             .fetch();
+    }
+
+    // 코스 상세 조회
+    @Override
+    public Optional<CourseDetailsProjection> findCourseDetailsProjection(Long courseId) {
+
+        CourseDetailsProjection result = queryFactory
+            .select(new QCourseDetailsProjection(
+                course.id,
+                course.name,
+                course.summary,
+                course.level,
+                course.distance,
+                course.estimatedTime,
+                course.sigun,
+                course.image,
+                course.gpxPath,
+                challenge.status,
+                challenge.endedAt,
+                Expressions.asBoolean(rewardEvent.status.eq(EventStatus.ACTIVE))
+                    .coalesce(false)
+            ))
+            .from(course)
+            .leftJoin(challenge).on(challenge.course.eq(course)
+                .and(challenge.status.eq(ChallengeStatus.ONGOING)))
+            .leftJoin(eventCourse).on(eventCourse.course.eq(course))
+            .leftJoin(eventCourse.rewardEvent, rewardEvent)
+            .where(course.id.eq(courseId))
+            .fetchOne();
+
+        return Optional.ofNullable(result);
     }
 
     // where절 기본 정의 메서드

--- a/src/main/java/com/saisai/domain/course/service/CourseService.java
+++ b/src/main/java/com/saisai/domain/course/service/CourseService.java
@@ -7,10 +7,10 @@ import com.saisai.config.jwt.AuthUserDetails;
 import com.saisai.domain.common.aws.s3.GpxS3;
 import com.saisai.domain.common.aws.s3.ImageUtil;
 import com.saisai.domain.common.exception.CustomException;
+import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
 import com.saisai.domain.course.dto.projection.CoursePageProjection;
 import com.saisai.domain.course.dto.response.CourseDetailsRes;
 import com.saisai.domain.course.dto.response.CoursePageRes;
-import com.saisai.domain.course.entity.Course;
 import com.saisai.domain.course.repository.CourseRepository;
 import com.saisai.domain.gpx.dto.GpxPoint;
 import com.saisai.domain.gpx.util.GpxParser;
@@ -94,18 +94,18 @@ public class CourseService {
         User user = userRepository.findById(authUserDetails.userId())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        Course course = courseRepository.findById(courseId)
+        CourseDetailsProjection course = courseRepository.findCourseDetailsProjection(courseId)
             .orElseThrow(() -> new CustomException(COURSE_NOT_FOUND));
 
-        boolean hasUnCompletedRide = rideRepository.existsActiveRideByUserIdAndCourseId(user.getId(), course.getId());
+        boolean hasUnCompletedRide = rideRepository.existsActiveRideByUserIdAndCourseId(user.getId(), courseId);
 
         RideCountRes rideCountRes = rideRepository.countRideByCourseId(courseId);
 
         List<String> themenames = themeRepository.findThemeNamesByCourseId(courseId);
 
-        String gpxContent = gpxS3.getGpxContent(course.getGpxPath());
+        String gpxContent = gpxS3.getGpxContent(course.gpxpath());
         List<GpxPoint> gpxPoints = gpxParser.parseGpxContent(gpxContent);
 
-        return CourseDetailsRes.from(course, imageUtil.getImageUrl(course.getImage()), rideCountRes, gpxPoints, hasUnCompletedRide, themenames);
+        return CourseDetailsRes.from(course, imageUtil.getImageUrl(course.imageUrl()), rideCountRes, gpxPoints, hasUnCompletedRide, themenames);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #61

## 📝 요약

> 코스상세조회Res Dto에 챌린지 상태, 종료일, 이벤트 여부 필드 추가
코스페이지조회Res Dto에서 summary 필드 삭제 

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
