### PR TITLE
[Bug(ride)] 코스 라이딩 완료 API Request 오류 해결

### DIFF
--- a/src/main/java/com/saisai/domain/ride/controller/RideController.java
+++ b/src/main/java/com/saisai/domain/ride/controller/RideController.java
@@ -74,7 +74,7 @@ public class RideController {
     @PatchMapping(value = "/rides/{rideId}/complete")
     public ResponseEntity<ApiResponse<Void>> completeRide(
         @PathVariable Long rideId,
-        @Valid RideCompleteReq completeReq,
+        @Valid @RequestBody RideCompleteReq completeReq,
         @Auth AuthUserDetails authUserDetails
     ) {
         rideService.completeRide(rideId, completeReq, authUserDetails);


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #78 

## 📝 요약

> `Controller`에서 요청 파라미터를 `RideCompleteReq`로 받는 메서드에 `@RequestBody`가 누락되어 있었음.
이로 인해 HTTP Body의 JSON payload를 객체에 매핑하지 못하고, 모든 필드를 `null`로 처리하여 `@NotNull` 관련 검증 오류가 발생함.

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
