### PR TITLE
[Feature(course)] 코스 조회 API에 정렬/필터링 추가

### DIFF
--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -87,6 +87,7 @@ public enum ExceptionCode {
     // etc
     INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "ETC_ER_01", "요청하신 페이지 번호가 유효 범위를 초과했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "ETC_ER_02", "서버가 응답할 수 없습니다."),
+    INVALID_SORT_OPTION(HttpStatus.BAD_REQUEST, "ETC_ER_03", "유효하지 않는 정렬 조건입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -33,6 +33,7 @@ public enum ExceptionCode {
     COURSE_DISTANCE_INVALID(HttpStatus.BAD_REQUEST, "CR_ER_04", "코스 거리 정보가 유효하지 않습니다."),
     COURSE_ALREADY_BOOKMARK(HttpStatus.CONFLICT, "CR_ER_05", "이미 북마크된 코스입니다."),
     COURSE_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "CR_ER_06", "코스 북마크를 찾을 수 없습니다."),
+    COURSE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR_ER_08", "해당 코스 타입을 찾을 수 없습니다."),
 
     // badge
     BADGE_NAME_DUPLICATE(HttpStatus.BAD_REQUEST, "BG_ER_01", "뱃지명이 중복됩니다."),

--- a/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/saisai/domain/common/exception/ExceptionCode.java
@@ -33,6 +33,7 @@ public enum ExceptionCode {
     COURSE_DISTANCE_INVALID(HttpStatus.BAD_REQUEST, "CR_ER_04", "코스 거리 정보가 유효하지 않습니다."),
     COURSE_ALREADY_BOOKMARK(HttpStatus.CONFLICT, "CR_ER_05", "이미 북마크된 코스입니다."),
     COURSE_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "CR_ER_06", "코스 북마크를 찾을 수 없습니다."),
+    INVALID_SORT_OPTION_FOR_COURSE_TYPE(HttpStatus.BAD_REQUEST, "CR_ER_07", "일반 코스에서는 종료일 기준으로 정렬할 수 없습니다."),
     COURSE_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "CR_ER_08", "해당 코스 타입을 찾을 수 없습니다."),
 
     // badge

--- a/src/main/java/com/saisai/domain/course/constant/CourseSortOption.java
+++ b/src/main/java/com/saisai/domain/course/constant/CourseSortOption.java
@@ -1,7 +1,11 @@
 package com.saisai.domain.course.constant;
 
+import static com.saisai.domain.challenge.entity.QChallenge.challenge;
 import static com.saisai.domain.common.exception.ExceptionCode.INVALID_SORT_OPTION;
+import static com.saisai.domain.course.entity.QCourse.course;
+import static com.saisai.domain.ride.entity.QRide.ride;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.saisai.domain.common.exception.CustomException;
 import java.util.Arrays;
 import lombok.Getter;
@@ -12,10 +16,30 @@ import org.springframework.data.domain.Sort;
 @RequiredArgsConstructor
 public enum CourseSortOption {
 
-    LEVEL_DESC("levelDesc", "level", Sort.Direction.DESC),
-    LEVEL_ASC("levelAsc", "level", Sort.Direction.ASC),
-    PARTICIPANTS_DESC("participantsDesc", "participants", Sort.Direction.DESC),
-    END_SOON("endSoon", "challenge_end_date", Sort.Direction.ASC),
+    LEVEL_DESC("levelDesc", "level", Sort.Direction.DESC) {
+        @Override
+        public OrderSpecifier<?> toOrderSpecifier() {
+            return course.level.desc();
+        }
+    },
+    LEVEL_ASC("levelAsc", "level", Sort.Direction.ASC) {
+        @Override
+        public OrderSpecifier<?> toOrderSpecifier() {
+            return course.level.asc();
+        }
+    },
+    PARTICIPANTS_DESC("participantsDesc", "participants", Sort.Direction.DESC){
+        @Override
+        public OrderSpecifier<?> toOrderSpecifier() {
+            return ride.count().desc();
+        }
+    },
+    END_SOON("endSoon", "challenge_end_date", Sort.Direction.ASC) {
+        @Override
+        public OrderSpecifier<?> toOrderSpecifier() {
+            return challenge.endedAt.asc();
+        }
+    },
 
     ;
 
@@ -23,7 +47,10 @@ public enum CourseSortOption {
     private final String sortColumn;
     private final Sort.Direction direction;
 
-    public static CourseSortOption of(String key) {
+    // QueryDSL OrderSpecifier 추상 메서드
+    public abstract OrderSpecifier<?> toOrderSpecifier();
+
+    public static CourseSortOption from(String key) {
         return Arrays.stream(values())
             .filter(opt -> opt.key.equalsIgnoreCase(key))
             .findFirst()

--- a/src/main/java/com/saisai/domain/course/constant/CourseSortOption.java
+++ b/src/main/java/com/saisai/domain/course/constant/CourseSortOption.java
@@ -1,0 +1,32 @@
+package com.saisai.domain.course.constant;
+
+import static com.saisai.domain.common.exception.ExceptionCode.INVALID_SORT_OPTION;
+
+import com.saisai.domain.common.exception.CustomException;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@Getter
+@RequiredArgsConstructor
+public enum CourseSortOption {
+
+    LEVEL_DESC("levelDesc", "level", Sort.Direction.DESC),
+    LEVEL_ASC("levelAsc", "level", Sort.Direction.ASC),
+    PARTICIPANTS_DESC("participantsDesc", "participants", Sort.Direction.DESC),
+    END_SOON("endSoon", "challenge_end_date", Sort.Direction.ASC),
+
+    ;
+
+    private final String key;
+    private final String sortColumn;
+    private final Sort.Direction direction;
+
+    public static CourseSortOption of(String key) {
+        return Arrays.stream(values())
+            .filter(opt -> opt.key.equalsIgnoreCase(key))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(INVALID_SORT_OPTION));
+    }
+}

--- a/src/main/java/com/saisai/domain/course/constant/CourseType.java
+++ b/src/main/java/com/saisai/domain/course/constant/CourseType.java
@@ -1,0 +1,24 @@
+package com.saisai.domain.course.constant;
+
+import static com.saisai.domain.common.exception.ExceptionCode.COURSE_TYPE_NOT_FOUND;
+
+import com.saisai.domain.common.exception.CustomException;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum CourseType {
+    CHALLENGE("challenge"),
+    GENERAL("general"),
+
+    ;
+
+    private final String value;
+
+    public static CourseType from(String value) {
+        return Arrays.stream(values())
+            .filter(type -> type.value.equals(value))
+            .findFirst()
+            .orElseThrow(() -> new CustomException(COURSE_TYPE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/saisai/domain/course/controller/CourseController.java
+++ b/src/main/java/com/saisai/domain/course/controller/CourseController.java
@@ -6,6 +6,8 @@ import static com.saisai.domain.common.response.SuccessCode.COURSE_LIST_GET_SUCC
 import com.saisai.config.jwt.AuthUserDetails;
 import com.saisai.domain.common.annotation.Auth;
 import com.saisai.domain.common.response.ApiResponse;
+import com.saisai.domain.course.constant.CourseSortOption;
+import com.saisai.domain.course.constant.CourseType;
 import com.saisai.domain.course.dto.response.CourseDetailsRes;
 import com.saisai.domain.course.dto.response.CoursePageRes;
 import com.saisai.domain.course.service.CourseService;
@@ -16,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,16 +36,23 @@ public class CourseController {
     private final CourseService courseService;
 
     @Operation(summary = "코스 전체 목록 조회",
-        description = "코스명, 요약, 난이도(상(3)/중(2)/하(1)), 거리(km), 예상 소요시간(분), 시군, 도전자 수, 완주자 수, 챌린지 상태(ENDED(종료)/ONGOING(진행 중)/UPCOMING(예정), 챌린지 종료일, 이벤트 여부, 지급 리워드 한 페이지 당 10개 씩 반환")
+        description = "코스명, 요약, 난이도(상(3)/중(2)/하(1)), 거리(km), 예상 소요시간(분), 시군, 참가자수,챌린지 상태, 챌린지 종료일, 이벤트 여부, 지급 리워드 한 페이지 당 10개 씩 반환")
     @GetMapping
     public ResponseEntity<ApiResponse<Page<CoursePageRes>>> getAllCourses(
         @Parameter(description = "페이지 번호") @RequestParam(defaultValue = "1") int page,
-        @Parameter(description = "챌린지 상태 (챌린지 중 = ONGOING). 미입력시 모든 코스 조회") @RequestParam(required = false) String challengeStatus
+        @Parameter(description = "challenge(챌린지 코스), general(일반 코스)") @RequestParam(defaultValue = "challenge") String type,
+        @Parameter(description = "levelAsc(난이도 낮은 순), levelDesc(난이도 높은 순), participantsDesc(참가자 순), endSoon(종료일 순)") @RequestParam(defaultValue = "levelAsc") String sort
     ) {
+        CourseType courseType = CourseType.from(type);
+        CourseSortOption sortOption = CourseSortOption.from(sort);
 
-        Pageable pageable = PageRequest.of(page - 1, 10);
+        Pageable pageable = PageRequest.of(
+            page - 1,
+            10,
+            Sort.by(sortOption.getDirection(), sortOption.getSortColumn())
+        );
         return ResponseEntity.status(HttpStatus.OK)
-            .body(ApiResponse.success(COURSE_LIST_GET_SUCCESS, courseService.getCourses(pageable, challengeStatus)));
+            .body(ApiResponse.success(COURSE_LIST_GET_SUCCESS, courseService.getCourses(pageable, courseType, sortOption)));
     }
 
     @Operation(summary = "코스 상세 조회",

--- a/src/main/java/com/saisai/domain/course/dto/projection/ChallengeCourseProjection.java
+++ b/src/main/java/com/saisai/domain/course/dto/projection/ChallengeCourseProjection.java
@@ -5,7 +5,7 @@ import com.saisai.domain.challenge.entity.ChallengeStatus;
 import com.saisai.domain.reward.dto.projection.RewardEventProjection;
 import java.time.LocalDateTime;
 
-public record CoursePageProjection(
+public record ChallengeCourseProjection(
     Long courseId,
     String courseName,
     Integer level,
@@ -20,6 +20,6 @@ public record CoursePageProjection(
 ) {
 
     @QueryProjection
-    public CoursePageProjection {
+    public ChallengeCourseProjection {
     }
 }

--- a/src/main/java/com/saisai/domain/course/dto/projection/ChallengeCourseProjection.java
+++ b/src/main/java/com/saisai/domain/course/dto/projection/ChallengeCourseProjection.java
@@ -13,6 +13,7 @@ public record CoursePageProjection(
     Double estimatedTime,
     String sigun,
     String imageUrl,
+    Long participantsCount,
     ChallengeStatus challengeStatus,
     LocalDateTime challengeEndedAt,
     RewardEventProjection rewardEventProjection

--- a/src/main/java/com/saisai/domain/course/dto/projection/GeneralCourseProjection.java
+++ b/src/main/java/com/saisai/domain/course/dto/projection/GeneralCourseProjection.java
@@ -1,0 +1,18 @@
+package com.saisai.domain.course.dto.projection;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record GeneralCourseProjection(
+    Long courseId,
+    String courseName,
+    Integer level,
+    Double distance,
+    Double estimatedTime,
+    String sigun,
+    String imageUrl,
+    Long participantsCount
+) {
+
+    @QueryProjection
+    public GeneralCourseProjection {}
+}

--- a/src/main/java/com/saisai/domain/course/dto/response/CoursePageRes.java
+++ b/src/main/java/com/saisai/domain/course/dto/response/CoursePageRes.java
@@ -1,11 +1,12 @@
 package com.saisai.domain.course.dto.response;
 
 import com.saisai.domain.challenge.entity.ChallengeStatus;
-import com.saisai.domain.course.dto.projection.CoursePageProjection;
+import com.saisai.domain.course.dto.projection.ChallengeCourseProjection;
+import com.saisai.domain.course.dto.projection.GeneralCourseProjection;
 import com.saisai.domain.reward.dto.projection.RewardEventProjection;
 import com.saisai.domain.reward.util.RewardUtils;
-import com.saisai.domain.ride.dto.response.RideCountRes;
 import java.time.LocalDate;
+import java.util.Optional;
 
 public record CoursePageRes(
     Long courseId,
@@ -15,40 +16,58 @@ public record CoursePageRes(
     Double estimatedTime,
     String sigun,
     String imageUrl,
-    Long courseChallengerCount,
-    Long courseFinisherCount,
+    Long participantsCount,
     ChallengeStatus challengeStatus,
     LocalDate challengeEndedAt,
     Boolean isEventActive,
     Integer reward
 ) {
 
-    public static CoursePageRes from(CoursePageProjection coursePageProjection, RideCountRes rideCountRes, String imageUrl) {
+    public static CoursePageRes from(ChallengeCourseProjection challengeCourseProjection, String imageUrl) {
 
-        RewardEventProjection rewardEventProjection = coursePageProjection.rewardEventProjection();
-        boolean isEventActive = rewardEventProjection.rewardEventId() != null;
+        RewardEventProjection rewardEventProjection = challengeCourseProjection.rewardEventProjection();
+
+        boolean isEventActive = Optional.ofNullable(challengeCourseProjection.rewardEventProjection())
+            .map(RewardEventProjection::rewardEventId)
+            .isPresent();
 
         Integer reward = isEventActive ?
             RewardUtils.calculateEventReward(
-                coursePageProjection.level(),
+                challengeCourseProjection.level(),
                 rewardEventProjection.rewardEventType(),
                 rewardEventProjection.value()) :
-            RewardUtils.calculateEventReward(coursePageProjection.level());
+            RewardUtils.calculateEventReward(challengeCourseProjection.level());
 
         return new CoursePageRes(
-            coursePageProjection.courseId(),
-            coursePageProjection.courseName(),
-            coursePageProjection.level(),
-            coursePageProjection.distance(),
-            coursePageProjection.estimatedTime(),
-            coursePageProjection.sigun(),
+            challengeCourseProjection.courseId(),
+            challengeCourseProjection.courseName(),
+            challengeCourseProjection.level(),
+            challengeCourseProjection.distance(),
+            challengeCourseProjection.estimatedTime(),
+            challengeCourseProjection.sigun(),
             imageUrl,
-            rideCountRes.courseChallengerCount(),
-            rideCountRes.courseFinisherCount(),
-            coursePageProjection.challengeStatus(),
-            coursePageProjection.challengeEndedAt().toLocalDate(),
+            challengeCourseProjection.participantsCount(),
+            challengeCourseProjection.challengeStatus(),
+            challengeCourseProjection.challengeEndedAt().toLocalDate(),
             isEventActive,
             reward
+        );
+    }
+
+    public static CoursePageRes from(GeneralCourseProjection generalCourseProjection, String imageUrl) {
+        return new CoursePageRes(
+            generalCourseProjection.courseId(),
+            generalCourseProjection.courseName(),
+            generalCourseProjection.level(),
+            generalCourseProjection.distance(),
+            generalCourseProjection.estimatedTime(),
+            generalCourseProjection.sigun(),
+            imageUrl,
+            generalCourseProjection.participantsCount(),
+            null,
+            null,
+            null,
+            null
         );
     }
 }

--- a/src/main/java/com/saisai/domain/course/repository/CourseRepositoryCustom.java
+++ b/src/main/java/com/saisai/domain/course/repository/CourseRepositoryCustom.java
@@ -1,17 +1,21 @@
 package com.saisai.domain.course.repository;
 
+import com.saisai.domain.course.constant.CourseSortOption;
 import com.saisai.domain.course.dto.projection.CourseCardProjection;
 import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
-import com.saisai.domain.course.dto.projection.CoursePageProjection;
+import com.saisai.domain.course.dto.projection.ChallengeCourseProjection;
+import com.saisai.domain.course.dto.projection.GeneralCourseProjection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CourseRepositoryCustom {
-    Page<CoursePageProjection> findCoursesByChallengeStatus(String challengeStatus, Pageable pageable);
-
     List<CourseCardProjection> findCourseCardByIds(List<Long> courseIds);
 
     Optional<CourseDetailsProjection> findCourseDetailsProjection(Long courseId);
+
+    Page<ChallengeCourseProjection> findChallengeCourses(Pageable pageable, CourseSortOption sortOption);
+
+    Page<GeneralCourseProjection> findGeneralCourses(Pageable pageable, CourseSortOption sortOption);
 }

--- a/src/main/java/com/saisai/domain/course/repository/CourseRepositoryImpl.java
+++ b/src/main/java/com/saisai/domain/course/repository/CourseRepositoryImpl.java
@@ -2,20 +2,22 @@ package com.saisai.domain.course.repository;
 
 import static com.saisai.domain.challenge.entity.QChallenge.challenge;
 import static com.saisai.domain.course.entity.QCourse.course;
-import static com.saisai.domain.reward.entity.QEventCourse.eventCourse;
 import static com.saisai.domain.reward.entity.QRewardEvent.rewardEvent;
+import static com.saisai.domain.ride.entity.QRide.ride;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.saisai.domain.challenge.entity.ChallengeStatus;
+import com.saisai.domain.course.constant.CourseSortOption;
+import com.saisai.domain.course.dto.projection.ChallengeCourseProjection;
 import com.saisai.domain.course.dto.projection.CourseCardProjection;
 import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
-import com.saisai.domain.course.dto.projection.CoursePageProjection;
+import com.saisai.domain.course.dto.projection.GeneralCourseProjection;
+import com.saisai.domain.course.dto.projection.QChallengeCourseProjection;
 import com.saisai.domain.course.dto.projection.QCourseCardProjection;
 import com.saisai.domain.course.dto.projection.QCourseDetailsProjection;
-import com.saisai.domain.course.dto.projection.QCoursePageProjection;
+import com.saisai.domain.course.dto.projection.QGeneralCourseProjection;
 import com.saisai.domain.reward.dto.projection.QRewardEventProjection;
 import com.saisai.domain.reward.entity.EventStatus;
 import java.util.List;
@@ -32,18 +34,13 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
-    // 전체 조회 메서드
+    // 일반 코스 조회
     @Override
-    public Page<CoursePageProjection> findCoursesByChallengeStatus(String challengeStatus, Pageable pageable) {
+    public Page<GeneralCourseProjection> findGeneralCourses(Pageable pageable,
+        CourseSortOption sortOption) {
 
-        BooleanBuilder searchConditions = searchConditions();
-
-        if (challengeStatus != null) {
-            searchConditions.and(challenge.status.eq(ChallengeStatus.valueOf(challengeStatus)));
-        }
-
-        List<CoursePageProjection> content = queryFactory
-            .select(new QCoursePageProjection(
+        List<GeneralCourseProjection> content = queryFactory
+            .select(new QGeneralCourseProjection(
                 course.id,
                 course.name,
                 course.level,
@@ -51,6 +48,51 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
                 course.estimatedTime,
                 course.sigun,
                 course.image,
+                ride.count().coalesce(0L)
+            ))
+            .from(course)
+            .leftJoin(challenge).on(
+                challenge.course.eq(course)
+                    .and(challenge.status.eq(ChallengeStatus.ONGOING))
+            )
+            .leftJoin(ride).on(ride.course.eq(course))
+            .where(course.isDeleted.eq(false)
+                .and(challenge.id.isNull()))
+            .groupBy(course.id, course.name, course.level, course.distance,
+                course.estimatedTime, course.sigun, course.image)
+            .orderBy(sortOption.toOrderSpecifier())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> query = queryFactory
+            .select(course.countDistinct())
+            .from(course)
+            .leftJoin(challenge).on(
+                challenge.course.eq(course)
+                    .and(challenge.status.eq(ChallengeStatus.ONGOING))
+            )
+            .where(course.isDeleted.eq(false)
+                .and(challenge.id.isNull()));
+
+        return PageableExecutionUtils.getPage(content, pageable, query::fetchOne);
+    }
+
+    // 챌린지 코스 조회
+    @Override
+    public Page<ChallengeCourseProjection> findChallengeCourses(Pageable pageable,
+        CourseSortOption sortOption) {
+
+        List<ChallengeCourseProjection> content = queryFactory
+            .select(new QChallengeCourseProjection(
+                course.id,
+                course.name,
+                course.level,
+                course.distance,
+                course.estimatedTime,
+                course.sigun,
+                course.image,
+                ride.count().coalesce(0L),
                 challenge.status,
                 challenge.endedAt,
                 new QRewardEventProjection(
@@ -60,22 +102,34 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
                     rewardEvent.value
                 )
             ))
-            .from(challenge)
-            .join(challenge.course, course)
-            .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent))
-            .where(searchConditions)
+            .from(course)
+            .leftJoin(challenge).on(
+                challenge.course.eq(course)
+                    .and(challenge.status.eq(ChallengeStatus.ONGOING))
+            )
+            .leftJoin(ride).on(ride.course.eq(course))
+            .leftJoin(rewardEvent).on(rewardEvent.challenge.eq(challenge))
+            .where(course.isDeleted.eq(false)
+                .and(challenge.id.isNotNull()))
+            .groupBy(course.id, course.name, course.level, course.distance,
+                course.estimatedTime, course.sigun, course.image,
+                challenge.status, challenge.endedAt,
+                rewardEvent.id, rewardEvent.status, rewardEvent.type, rewardEvent.value)
+            .orderBy(sortOption.toOrderSpecifier())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
 
         JPAQuery<Long> total = queryFactory
             .select(course.countDistinct())
-            .from(challenge)
-            .join(challenge.course, course)
-            .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent))
-            .where(searchConditions);
+            .from(course)
+            .leftJoin(challenge).on(
+                challenge.course.eq(course)
+                    .and(challenge.status.eq(ChallengeStatus.ONGOING))
+            )
+            .leftJoin(rewardEvent).on(rewardEvent.challenge.eq(challenge))
+            .where(course.isDeleted.eq(false)
+                .and(challenge.id.isNotNull()));
 
         return PageableExecutionUtils.getPage(content, pageable, total::fetchOne);
     }
@@ -100,8 +154,7 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
                 )
             ))
             .from(course)
-            .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(rewardEvent).on(eventCourse.rewardEvent.eq(rewardEvent))
+            .leftJoin(rewardEvent).on(rewardEvent.challenge.eq(challenge))  // 이거 챌린지로 이동해야할듯
             .where(course.id.in(courseIds))
             .fetch();
     }
@@ -129,20 +182,10 @@ public class CourseRepositoryImpl implements CourseRepositoryCustom {
             .from(course)
             .leftJoin(challenge).on(challenge.course.eq(course)
                 .and(challenge.status.eq(ChallengeStatus.ONGOING)))
-            .leftJoin(eventCourse).on(eventCourse.course.eq(course))
-            .leftJoin(eventCourse.rewardEvent, rewardEvent)
+            .leftJoin(rewardEvent).on(rewardEvent.challenge.eq(challenge)) // 여기 동적 조건 추가해야할듯. 챌린지인지 아닌지.
             .where(course.id.eq(courseId))
             .fetchOne();
 
         return Optional.ofNullable(result);
-    }
-
-    // where절 기본 정의 메서드
-    private BooleanBuilder searchConditions() {
-        BooleanBuilder builder = new BooleanBuilder();
-
-        builder.and(course.isDeleted.eq(false));
-
-        return builder;
     }
 }

--- a/src/main/java/com/saisai/domain/course/service/CourseService.java
+++ b/src/main/java/com/saisai/domain/course/service/CourseService.java
@@ -1,14 +1,18 @@
 package com.saisai.domain.course.service;
 
 import static com.saisai.domain.common.exception.ExceptionCode.COURSE_NOT_FOUND;
+import static com.saisai.domain.common.exception.ExceptionCode.INVALID_SORT_OPTION_FOR_COURSE_TYPE;
 import static com.saisai.domain.common.exception.ExceptionCode.USER_NOT_FOUND;
 
 import com.saisai.config.jwt.AuthUserDetails;
 import com.saisai.domain.common.aws.s3.GpxS3;
 import com.saisai.domain.common.aws.s3.ImageUtil;
 import com.saisai.domain.common.exception.CustomException;
+import com.saisai.domain.course.constant.CourseSortOption;
+import com.saisai.domain.course.constant.CourseType;
+import com.saisai.domain.course.dto.projection.ChallengeCourseProjection;
 import com.saisai.domain.course.dto.projection.CourseDetailsProjection;
-import com.saisai.domain.course.dto.projection.CoursePageProjection;
+import com.saisai.domain.course.dto.projection.GeneralCourseProjection;
 import com.saisai.domain.course.dto.response.CourseDetailsRes;
 import com.saisai.domain.course.dto.response.CoursePageRes;
 import com.saisai.domain.course.repository.CourseRepository;
@@ -19,7 +23,6 @@ import com.saisai.domain.ride.repository.RideRepository;
 import com.saisai.domain.user.entity.User;
 import com.saisai.domain.user.repository.UserRepository;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -42,32 +45,43 @@ public class CourseService {
     private final UserRepository userRepository;
 
     // 코스 목록 조회 메서드
-    public Page<CoursePageRes> getCourses(Pageable pageable, String challengeStatus) {
-        Page<CoursePageProjection> coursePage = courseRepository.findCoursesByChallengeStatus(challengeStatus, pageable);
+    public Page<CoursePageRes> getCourses(Pageable pageable, CourseType type, CourseSortOption sortOption) {
 
-        List<Long> courseIds = coursePage.getContent().stream()
-            .map(CoursePageProjection::courseId)
-            .toList();
+        return switch (type) {
+            case CHALLENGE -> fetchChallengeCoursesAsPage(pageable, sortOption);
+            case GENERAL -> fetchGeneralCoursesAsPage(pageable, sortOption);
+        };
+    }
 
-        final Map<Long, RideCountRes> rideCountResMap = rideRepository.countRidesMapByCourseIds(courseIds);
+    // 챌린지 코스 조회
+    private Page<CoursePageRes> fetchGeneralCoursesAsPage(Pageable pageable, CourseSortOption sortOption) {
 
-        List<CoursePageRes> result = coursePage.getContent().stream()
-            .map(projection -> {
-                RideCountRes rideCountRes = rideCountResMap.getOrDefault(
-                    projection.courseId(),
-                    RideCountRes.empty(projection.courseId())
-                );
+        if (sortOption.equals(CourseSortOption.END_SOON)) {
+            throw new CustomException(INVALID_SORT_OPTION_FOR_COURSE_TYPE);
+        }
 
-                return CoursePageRes.from(
+        Page<GeneralCourseProjection> generalPage = courseRepository.findGeneralCourses(pageable, sortOption);
+        List<CoursePageRes> result = generalPage.getContent().stream()
+            .map(projection ->
+                CoursePageRes.from(
                     projection,
-                    rideCountRes,
                     imageUtil.getImageUrl(projection.imageUrl())
-                );
-
-            })
+                ))
             .toList();
+        return new PageImpl<>(result, pageable, generalPage.getTotalElements());
+    }
 
-        return new PageImpl<>(result, pageable, coursePage.getTotalElements());
+    // 일반 코스 조회
+    private Page<CoursePageRes> fetchChallengeCoursesAsPage(Pageable pageable, CourseSortOption sortOption) {
+        Page<ChallengeCourseProjection> challengePage = courseRepository.findChallengeCourses(pageable, sortOption);
+        List<CoursePageRes> result = challengePage.getContent().stream()
+            .map(projection ->
+                CoursePageRes.from(
+                    projection,
+                    imageUtil.getImageUrl(projection.imageUrl())
+                ))
+            .toList();
+        return new PageImpl<>(result, pageable, challengePage.getTotalElements());
     }
 
     // 코스 상세 조회 비즈니스 로직

--- a/src/main/java/com/saisai/domain/reward/repository/RewardEventRepository.java
+++ b/src/main/java/com/saisai/domain/reward/repository/RewardEventRepository.java
@@ -12,7 +12,7 @@ public interface RewardEventRepository extends JpaRepository<RewardEvent, Long> 
     // 이벤트 겹치는 코스ID 조회
     @Query("SELECT re.challenge.id FROM RewardEvent re " +
         "WHERE re.challenge.id IN :challengeIds " +
-        "AND re..status IN ('SCHEDULED', 'ACTIVE') " +
+        "AND re.status IN ('SCHEDULED', 'ACTIVE') " +
         "AND ((re.startTime <= :endTime AND re.endTime >= :startTime))")
     List<Long> findConflictingChallengeIds(@Param("challengeIds") List<Long> challengeIds,
                                         @Param("startTime") LocalDateTime startTime,


### PR DESCRIPTION
## 🔗 연관된 이슈

> close #80 

## 📝 요약

> 코스 조회 시 챌린지/일반 코스 필터링 기능 추가
정렬 추가
이에 따라 코스 조회 로직을 챌린지/일반으로 분리

## 💬 참고사항

> 고민했던 부분이나, 이해를 위해 참고할 내용

## ✅ PR Checklist

> PR이 다음 요구 사항을 충족했는지 확인하기!

- [x]  커밋 메시지 컨벤션 준수
- [x]  정상 동작 테스트 여부 체크
